### PR TITLE
Nil options value removes corresponding key

### DIFF
--- a/lib/tweet-button.rb
+++ b/lib/tweet-button.rb
@@ -43,7 +43,7 @@ module TweetButton
   
   def options_to_data_params(opts)
     params = {}
-    opts.each {|k, v| params["data-#{k}"] = v}
+    opts.reject {|k,v| v.nil? }.each {|k, v| params["data-#{k}"] = v}
     
     # Make sure the CSS class is there
     params['class'] = 'twitter-share-button'
@@ -52,7 +52,7 @@ module TweetButton
   
   # I'm pretty sure this is in the stdlib or Rails somewhere.  Too lazy to figure it out now.
   def options_to_query_string(opts)
-    opts.map{|k,v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v)}"}.join("&")
+    opts.reject {|k,v| v.nil? }.map{|k,v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v)}"}.join("&")
   end
   
   def html_safe_string(str)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'test/unit'
+require 'cgi'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/test_tweet-button.rb
+++ b/test/test_tweet-button.rb
@@ -1,12 +1,22 @@
 require 'helper'
 
 class TestTweetButton < Test::Unit::TestCase
+  require 'action_view'
+  
+  include ActionView::Helpers::UrlHelper
   include TweetButton
   
-  def test_permits_nil_via
-    assert_equal  "url=http%3A%2F%2Fexample.com&text=Text",
-                  options_to_query_string(:text => "Text", :via => nil, :url => "http://example.com"),
-                  "Generates a proper options string for nil via"
-                  
+  def request
+    Struct.new(:url)["http://example.com"]
+  end
+  
+  def test_permits_nil_options
+    assert_no_match /via/,
+                    options_to_query_string(:text => "Text", :via => nil, :url => "http://example.com"),
+                    "Generates a proper options string for nil via"
+    assert_no_match /via/, custom_tweet_button("Tweet", :via => nil),
+                    "Generates a proper custom tweet button"
+    assert_no_match /data-via/, tweet_button(:via => nil),
+                    "Generates a proper tweet button"
   end
 end

--- a/test/test_tweet-button.rb
+++ b/test/test_tweet-button.rb
@@ -1,7 +1,12 @@
 require 'helper'
 
 class TestTweetButton < Test::Unit::TestCase
-  def test_something_for_real
-    flunk "hey buddy, you should probably rename this file and start testing for real"
+  include TweetButton
+  
+  def test_permits_nil_via
+    assert_equal  "url=http%3A%2F%2Fexample.com&text=Text",
+                  options_to_query_string(:text => "Text", :via => nil, :url => "http://example.com"),
+                  "Generates a proper options string for nil via"
+                  
   end
 end


### PR DESCRIPTION
This branch modifies `options_to_data_params` and `options_to_query_string` to make them detect and remove keys with nil values.  As a result, you can now set an option to nil to ensure it's removed, even if it's in the default set of values.

This also adds three tests to make sure it all works.
